### PR TITLE
Update cleanup tool version

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   cleanup:
-    uses: giantswarm/app-catalog-cleanup-tool/.github/workflows/cleDanup.yaml@v0.2.6
+    uses: giantswarm/app-catalog-cleanup-tool/.github/workflows/cleanup.yaml@v0.2.6
     with:
       delete-before: "1 month"
       dry-run: false

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,13 +1,11 @@
 name: Default Test Catalog Cleanup
-
 on:
   schedule:
     - cron: '0 0 1 * *'
   workflow_dispatch:
-
 jobs:
   cleanup:
-    uses: giantswarm/app-catalog-cleanup-tool/.github/workflows/cleanup.yaml@v0.2.5
+    uses: giantswarm/app-catalog-cleanup-tool/.github/workflows/cleDanup.yaml@v0.2.6
     with:
       delete-before: "1 month"
       dry-run: false


### PR DESCRIPTION
The lates version of the cleanup tool is 0.2.6: https://github.com/giantswarm/app-catalog-cleanup-tool/releases/tag/v0.2.6